### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.springsource.org/libs-release'}
-		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.springsource.org/libs-release'}
+		maven { url 'https://repo.springsource.org/plugins-release' }
 	}
 }
 
@@ -19,7 +19,7 @@ configure(allprojects) {
 
 	repositories {
 		mavenCentral()
-		maven { url "http://repo.springsource.org/libs-release" }
+		maven { url "https://repo.springsource.org/libs-release" }
 	}
 
 	task integrationTest(type: Test) {
@@ -106,7 +106,7 @@ configure(rootProject) {
 		options.header = rootProject.description
 		options.overview = 'src/api/overview.html'
 		options.links(
-			'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+			'https://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
 		)
 		source subprojects.collect { project ->
 			project.sourceSets.main.allJava

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
             url = 'https://github.com/spring-projects/spring-data-grid'
             organization {
                 name = 'SpringSource'
-                url = 'http://spring.io/spring-data-grid'
+                url = 'https://spring.io/spring-data-grid'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector) result 301).
* http://repo.springsource.org/libs-release migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://spring.io/spring-data-grid migrated to:  
  https://spring.io/spring-data-grid ([https](https://spring.io/spring-data-grid) result 302).