### PR TITLE
URL Cleanup

### DIFF
--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGrid.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGridGroups.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGridGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGroup.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerGroup.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerNode.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/ContainerNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/GroupsRebalanceData.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/GroupsRebalanceData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/ManagedContainerGridGroups.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/ManagedContainerGridGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/AbstractCompositeListener.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/AbstractCompositeListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/ContainerGridGroupsListener.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/ContainerGridGroupsListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/ContainerGridListener.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/ContainerGridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/DefaultContainerGridGroupsListener.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/DefaultContainerGridGroupsListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/DefaultContainerGridListener.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/DefaultContainerGridListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/OrderedComposite.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/listener/OrderedComposite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractContainerGrid.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractContainerGrid.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractContainerGridGroups.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractContainerGridGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractManagedContainerGridGroups.java
+++ b/spring-data-grid-core/src/main/java/org/springframework/data/grid/support/AbstractManagedContainerGridGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractContainerGridGroupsTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractContainerGridGroupsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractContainerGridTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractContainerGridTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractExtendedInterfacesTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractExtendedInterfacesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractRebalanceTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/AbstractRebalanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/ContainerGridGroupsTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/ContainerGridGroupsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/ContainerGridTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/ContainerGridTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/ExtendedInterfacesTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/ExtendedInterfacesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-data-grid-core/src/test/java/org/springframework/data/grid/RebalanceTests.java
+++ b/spring-data-grid-core/src/test/java/org/springframework/data/grid/RebalanceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 23 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).